### PR TITLE
UC-75: Create Jenkins-based CI pipeline for training an Azure ML model 

### DIFF
--- a/diabetes_regression/conda_dependencies.yml
+++ b/diabetes_regression/conda_dependencies.yml
@@ -37,3 +37,6 @@ dependencies:
 
       # MLOps with R
       - azure-storage-blob
+
+      - opencensus==0.7.10
+      - opencensus-ext-azure==1.0.4

--- a/diabetes_regression/conda_dependencies.yml
+++ b/diabetes_regression/conda_dependencies.yml
@@ -37,6 +37,3 @@ dependencies:
 
       # MLOps with R
       - azure-storage-blob
-
-      - opencensus==0.7.10
-      - opencensus-ext-azure==1.0.4

--- a/jenkins-pipelines/.properties
+++ b/jenkins-pipelines/.properties
@@ -1,0 +1,85 @@
+SOURCES_DIR_TRAIN=diabetes_regression
+# The path to the model training script under SOURCES_DIR_TRAIN
+TRAIN_SCRIPT_PATH=training/train_aml.py
+# The path to the model evaluation script under SOURCES_DIR_TRAIN
+EVALUATE_SCRIPT_PATH=evaluate/evaluate_model.py
+# The path to the model registration script under SOURCES_DIR_TRAIN
+REGISTER_SCRIPT_PATH=register/register_model.py
+# The path to the model scoring script relative to SOURCES_DIR_TRAIN
+SCORE_SCRIPT=scoring/score.py
+
+
+# Azure ML Variables
+EXPERIMENT_NAME=mlopspython
+DATASET_NAME=diabetes_ds
+# Uncomment DATASTORE_NAME if you have configured non default datastore to point to your data
+# DATASTORE_NAME
+#   datablobstore
+DATASET_VERSION=latest
+TRAINING_PIPELINE_NAME=diabetes-Training-Pipeline
+MODEL_NAME=diabetes_regression_model.pkl
+
+# AML Compute Cluster Config
+AML_ENV_NAME=diabetes_regression_training_env
+AML_ENV_TRAIN_CONDA_DEP_FILE=conda_dependencies.yml
+AML_COMPUTE_CLUSTER_CPU_SKU=STANDARD_DS2_V2
+AML_COMPUTE_CLUSTER_NAME=train-cluster
+AML_CLUSTER_MIN_NODES=0
+AML_CLUSTER_MAX_NODES=4
+AML_CLUSTER_PRIORITY=lowpriority
+
+# The name for the (docker/webapp) scoring image
+IMAGE_NAME="diabetestrained"
+
+# Optional. Used by a training pipeline with R on Databricks
+
+# These are the default values set in ml_service\util\env_variables.py. Uncomment and override if desired.
+# Set to false to disable the evaluation step in the ML pipeline and register the newly trained model unconditionally.
+#  RUN_EVALUATION
+#   "true"
+# Set to false to register the model regardless of the outcome of the evaluation step in the ML pipeline.
+#  ALLOW_RUN_CANCEL
+#   "true"
+
+# Flag to allow rebuilding the AML Environment after it was built for the first time. This enables dependency updates from conda_dependencies.yaml.
+#  AML_REBUILD_ENVIRONMENT
+#  "false"
+
+# Variables below are used for controlling various aspects of batch scoring
+USE_GPU_FOR_SCORING=False
+# Conda dependencies for the batch scoring step
+AML_ENV_SCORE_CONDA_DEP_FILE=conda_dependencies_scoring.yml
+# Conda dependencies for the score copying step
+AML_ENV_SCORECOPY_CONDA_DEP_FILE=conda_dependencies_scorecopy.yml
+# AML Compute Cluster Config for parallel batch scoring
+AML_ENV_NAME_SCORING=diabetes_regression_scoring_env
+AML_ENV_NAME_SCORE_COPY=diabetes_regression_score_copy_env
+AML_COMPUTE_CLUSTER_CPU_SKU_SCORING=STANDARD_DS2_V2
+AML_COMPUTE_CLUSTER_NAME_SCORING=score-cluster
+AML_CLUSTER_MIN_NODES_SCORING=0
+AML_CLUSTER_MAX_NODES_SCORING=4
+AML_CLUSTER_PRIORITY_SCORING=lowpriority
+# The path to the batch scoring script relative to SOURCES_DIR_TRAIN
+BATCHSCORE_SCRIPT_PATH=scoring/parallel_batchscore.py
+BATCHSCORE_COPY_SCRIPT_PATH=scoring/parallel_batchscore_copyoutput.py
+# Flag to allow rebuilding the AML Environment after it was built for the first time.
+# This enables dependency updates from the conda dependencies yaml for scoring activities.
+AML_REBUILD_ENVIRONMENT_SCORING="true"
+
+# Datastore config for scoring
+# The storage account name and key are supplied as variables in a variable group
+# in the Azure Pipelines library for this project. Please refer to repo docs for
+# more details
+
+# Blob container where the input data for scoring can be found
+SCORING_DATASTORE_INPUT_CONTAINER="input"
+# Blobname for the input data - include any applicable path in the string
+SCORING_DATASTORE_INPUT_FILENAME="diabetes_scoring_input.csv"
+# Blob container where the output data for scoring can be found
+SCORING_DATASTORE_OUTPUT_CONTAINER="output"
+# Blobname for the output data - include any applicable path in the string
+SCORING_DATASTORE_OUTPUT_FILENAME="diabetes_scoring_output.csv"
+# Dataset name for input data for scoring
+SCORING_DATASET_NAME="diabetes_scoring_ds"
+# Scoring pipeline name
+SCORING_PIPELINE_NAME="diabetes-scoring-pipeline"

--- a/jenkins-pipelines/Jenkinsfile
+++ b/jenkins-pipelines/Jenkinsfile
@@ -1,0 +1,54 @@
+/*
+* CI Pipeline to build, publish and run the ML Training Pipeline.
+* Pipeline uses docker image as an agent.
+*/
+pipeline {
+    agent {
+        docker {
+            //Azure CLI commands require root privileges
+            image 'mcr.microsoft.com/mlops/python:latest'
+            args "--user root --privileged"
+        }
+    }
+    stages {
+        stage('Build, Publish and Run AML Pipeline') {
+            environment {
+                WORKSPACE_NAME = 'swsundar-ml'
+                SUBSCRIPTION_ID = '371e8e7f-bce0-4db0-9df5-d88805b41101'
+                RESOURCE_GROUP = 'swsundar-upskill'
+            }
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: '*/master']],
+                    userRemoteConfigs: [[url: 'https://github.com/Merlion-Crew/MLOpsPython.git/']]])
+
+                withCredentials([azureServicePrincipal('swsundar-azure-spn')]) {
+                    sh '''
+                        az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID
+                        az account set -s $SUBSCRIPTION_ID
+                    '''
+                }
+
+                script {
+                    echo "Load the variables from the properties file and set them as environment variables\n"
+                    def props = readProperties file: './jenkins-pipelines/.properties'
+                    keys= props.keySet()
+                    for(key in keys) {
+                        value = props["${key}"]
+                        env."${key}" = "${value}"
+                    }
+                    echo "Environment variables loaded"
+
+                    //Build the Azure ML Pipeline
+                    echo "====== Publish the Azure ML Pipeline ======"
+                    sh 'python -m ml_service.pipelines.diabetes_regression_build_train_pipeline'
+
+                    //Run the Azure ML Pipeline and save the pipeline run id in a text file
+                    echo "====== Run the Azure ML Pipeline ======\n"
+                    sh 'python -m ml_service.pipelines.run_train_pipeline --output_pipeline_id_file "pipeline_id.txt"'
+
+                    //TODO: Fetch the status of the pipeline run
+                }
+            }
+        }
+    }
+}

--- a/jenkins-pipelines/Jenkinsfile
+++ b/jenkins-pipelines/Jenkinsfile
@@ -10,12 +10,16 @@ pipeline {
             args "--user root --privileged"
         }
     }
+    parameters {
+        string(name: 'WORKSPACE_NAME', defaultValue: 'swsundar-ml', description: 'Azure Machine Learning Workspace Name')
+        string(name: 'SUBSCRIPTION_ID', defaultValue: '371e8e7f-bce0-4db0-9df5-d88805b41101', description: 'Azure Subscription ID')
+        string(name: 'RESOURCE_GROUP', defaultValue: 'swsundar-upskill', description: 'Azure Resource Group Name')
+        string(name: 'SERVICE_PRINCIPAL_NAME', defaultValue: 'swsundar-azure-spn', description: 'Azure Service Principal Name')
+    }
     stages {
         stage('Build, Publish and Run AML Pipeline') {
             environment {
-                WORKSPACE_NAME = 'swsundar-ml'
-                SUBSCRIPTION_ID = '371e8e7f-bce0-4db0-9df5-d88805b41101'
-                RESOURCE_GROUP = 'swsundar-upskill'
+                BUILD_BUILDID = "${env.BUILD_ID}"
             }
             steps {
                 checkout([$class: 'GitSCM', branches: [[name: '*/master']],
@@ -30,7 +34,7 @@ pipeline {
 
                 script {
                     echo "Load the variables from the properties file and set them as environment variables\n"
-                    def props = readProperties file: './jenkins-pipelines/.properties'
+                    def props = readProperties file: '.properties'
                     keys= props.keySet()
                     for(key in keys) {
                         value = props["${key}"]

--- a/jenkins-pipelines/diabetes_regression_ci-Jenkinsfile
+++ b/jenkins-pipelines/diabetes_regression_ci-Jenkinsfile
@@ -25,10 +25,10 @@ pipeline {
                 checkout([$class: 'GitSCM', branches: [[name: '*/master']],
                     userRemoteConfigs: [[url: 'https://github.com/Merlion-Crew/MLOpsPython.git/']]])
 
-                withCredentials([azureServicePrincipal('swsundar-azure-spn')]) {
+                withCredentials([azureServicePrincipal("${params.SERVICE_PRINCIPAL_NAME}")]) {
                     sh '''
                         az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID
-                        az account set -s $SUBSCRIPTION_ID
+                        az account set -s $AZURE_SUBSCRIPTION_ID
                     '''
                 }
 

--- a/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
+++ b/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
@@ -12,6 +12,8 @@ import os
 
 def main():
     e = Env()
+    print(f"{e.workspace_name}")
+    print(f"{e.resource_group}")
     # Get Azure machine learning workspace
     aml_workspace = Workspace.get(
         name=e.workspace_name,
@@ -170,7 +172,7 @@ def main():
     published_pipeline = train_pipeline.publish(
         name=e.pipeline_name,
         description="Model training/retraining pipeline",
-        version=e.build_id,
+        version=e.build_id
     )
     print(f"Published pipeline: {published_pipeline.name}")
     print(f"for build {published_pipeline.version}")

--- a/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
+++ b/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
@@ -12,8 +12,6 @@ import os
 
 def main():
     e = Env()
-    print(f"{e.workspace_name}")
-    print(f"{e.resource_group}")
     # Get Azure machine learning workspace
     aml_workspace = Workspace.get(
         name=e.workspace_name,


### PR DESCRIPTION
### Summary:
- Create a CI pipeline in Jenkins publishing Azure ML pipeline and training a model in Azure ML
- Use docker image as an agent in the Jenkins pipeline
- Load all environment variables from a properties file in Jenkins pipeline

### Test:
Jenkins Pipeline Run: http://merlion-jenkins-vm.eastasia.cloudapp.azure.com:8080/job/swsundar-build-aml-pipeline/

