### PR TITLE
UC-106: Integrate App Insights

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ BASE_NAME = ''
 SP_APP_ID = ''
 SP_APP_SECRET = ''
 RESOURCE_GROUP = 'mlops-RG'
+APPINSIGHTS_INSTRUMENTATION_KEY = ''
 
 # Mock build/release ID for local testing
 BUILD_BUILDID = '001'

--- a/diabetes_regression/ci_dependencies.yml
+++ b/diabetes_regression/ci_dependencies.yml
@@ -27,3 +27,5 @@ dependencies:
       - flake8==3.7.*
       - flake8_formatter_junit_xml==0.0.*
       - azure-cli==2.3.*
+      - opencensus==0.7.10
+      - opencensus-ext-azure==1.0.4

--- a/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
+++ b/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
@@ -9,23 +9,27 @@ from ml_service.util.env_variables import Env
 from ml_service.util.manage_environment import get_environment
 import os
 
+from ml_service.util.logger import setup_logging
+import logging
 
 def main():
     e = Env()
+    setup_logging(False)
+
     # Get Azure machine learning workspace
     aml_workspace = Workspace.get(
         name=e.workspace_name,
         subscription_id=e.subscription_id,
         resource_group=e.resource_group,
     )
-    print("get_workspace:")
-    print(aml_workspace)
+    logging.info("get_workspace:")
+    logging.info(aml_workspace)
 
     # Get Azure machine learning cluster
     aml_compute = get_compute(aml_workspace, e.compute_name, e.vm_size)
     if aml_compute is not None:
-        print("aml_compute:")
-        print(aml_compute)
+        logging.info("aml_compute:")
+        logging.info(aml_compute)
 
     # Create a reusable Azure ML environment
     environment = get_environment(
@@ -124,7 +128,7 @@ def main():
         runconfig=run_config,
         allow_reuse=True,
     )
-    print("Step Train created")
+    logging.info("Step Train created")
 
     evaluate_step = PythonScriptStep(
         name="Evaluate Model ",
@@ -152,15 +156,15 @@ def main():
         runconfig=run_config,
         allow_reuse=False,
     )
-    print("Step Register created")
+    logging.info("Step Register created")
     # Check run_evaluation flag to include or exclude evaluation step.
     if (e.run_evaluation).lower() == "true":
-        print("Include evaluation step before register step.")
+        logging.info("Include evaluation step before register step.")
         evaluate_step.run_after(train_step)
         register_step.run_after(evaluate_step)
         steps = [train_step, evaluate_step, register_step]
     else:
-        print("Exclude evaluation step and directly run register step.")
+        logging.info("Exclude evaluation step and directly run register step.")
         register_step.run_after(train_step)
         steps = [train_step, register_step]
 
@@ -172,8 +176,8 @@ def main():
         description="Model training/retraining pipeline",
         version=e.build_id,
     )
-    print(f"Published pipeline: {published_pipeline.name}")
-    print(f"for build {published_pipeline.version}")
+    logging.info(f"Published pipeline: {published_pipeline.name}")
+    logging.info(f"for build {published_pipeline.version}")
 
 
 if __name__ == "__main__":

--- a/ml_service/util/env_variables.py
+++ b/ml_service/util/env_variables.py
@@ -22,6 +22,7 @@ class Env:
     app_secret: Optional[str] = os.environ.get("SP_APP_SECRET")
     vm_size: Optional[str] = os.environ.get("AML_COMPUTE_CLUSTER_CPU_SKU")
     compute_name: Optional[str] = os.environ.get("AML_COMPUTE_CLUSTER_NAME")
+    appinsights_instrumentation_key: Optional[str] = os.environ.get("APPINSIGHTS_INSTRUMENTATION_KEY")
     vm_priority: Optional[str] = os.environ.get(
         "AML_CLUSTER_PRIORITY", "lowpriority"
     )  # NOQA: E501

--- a/ml_service/util/logger.py
+++ b/ml_service/util/logger.py
@@ -17,7 +17,7 @@ def setup_logging(log_to_local_only: bool = False, env: Env = None):
     """
     if env is None:
         env = Env()
-    print(env)
+    
     logging.config.dictConfig(logging_config)
     logger = getLogger()
 

--- a/ml_service/util/logger.py
+++ b/ml_service/util/logger.py
@@ -1,0 +1,34 @@
+from logging import Formatter, getLogger, DEBUG, INFO, StreamHandler
+import logging.config
+from opencensus.ext.azure.log_exporter import AzureLogHandler
+
+from ml_service.util.env_variables import Env
+from ml_service.util.logging_config import logging_config
+
+
+def setup_logging(log_to_local_only: bool = False, env: Env = None):
+    """Log Utility method to setup python logging with necessary
+       configuration to publish logs locally or to cloud
+
+    Keyword Arguments:
+        log_to_local_only (bool) -- Set to True if you want to publish logs to stream only.   (default: {False})
+                                    False indicates logs will be published to Azure (AppInsights Service is used here)
+        env (Env) -- an instance of Env class that loads & stores all environment variables. Used for UT (default: {None})
+    """
+    if env is None:
+        env = Env()
+    print(env)
+    logging.config.dictConfig(logging_config)
+    logger = getLogger()
+
+    if not log_to_local_only:
+    # Assumes the environment variable APPLICATIONINSIGHTS_CONNECTION_STRING is already set
+        azure_log_handler = AzureLogHandler(
+            instrumentation_key=env.appinsights_instrumentation_key,
+            storage_path='logs'
+        )
+        azure_log_handler.setLevel(INFO)
+        logger.addHandler(azure_log_handler)
+
+if __name__ == "__main__":
+    setup_logging(True)

--- a/ml_service/util/logging_config.py
+++ b/ml_service/util/logging_config.py
@@ -1,0 +1,37 @@
+""" This file is used to setup the logging configuration as a dictionary.
+    This dictionary object passed in to the logger utility class to decide the format,
+    handlers (console, file, etc.) and log levels.
+"""
+import time
+import logging
+
+class UTCFormatter(logging.Formatter):
+    converter = time.gmtime
+
+logging_config = {
+    'version': 1,
+    'formatters': {
+        'utc': {
+            '()': UTCFormatter,
+            'format': '%(asctime)s %(module)s.%(funcName)s:%(lineno)d [%(levelname)s]- %(message)s'
+        }
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': 'DEBUG',
+            'formatter': 'utc',
+            'stream': 'ext://sys.stdout'
+        }
+    },
+    'loggers': {
+        'basic': {
+            'level': 'DEBUG',
+            'handlers': ['console']
+        }
+    },
+    'root': {
+        'level': 'DEBUG',
+        'handlers': ['console']
+    }
+}


### PR DESCRIPTION
This PR includes the integration of app insights on the ML pipeline:

# Description:
This PR includes the integration of Application Insights on the pipeline. This uses the `opencensus` library. The conda dependency file that has been changed is the `diabetes_regression/ci_dependencies.yml`. 

Create your conda environment, run this: 
1. `conda env create -f diabetes_regression/ci_dependencies.yml`
1. `conda activate mlopspython_ci`

Update your conda environment with the newly updated `diabetes_regression/ci_dependencies.yml` file, run this:
1. `conda env update --file ./diabetes_regression/ci_dependencies.yml --prune`

## To run this PR:
1. Create a copy of `.env.example` to `.env` file
1. Supply the necessary data on the newly created `.env` file
1. Run the `ml_service/pipelines/diabetes_regression_build_train_pipeline.py` script by running this command:
    ```
    python -m ml_service.pipelines.diabetes_regression_build_train_pipeline
    ```
1. Once everything is done, you should be seeing something like this on the Application Insights you've configured this run would connect to.
    ![image](https://user-images.githubusercontent.com/308396/93537456-1a42c380-f97e-11ea-9d3a-9b90f5e43ce4.png)
