### PR TITLE
UC-136: Log model metric to `customMetric` table of App insights

### DIFF
--- a/diabetes_regression/training/train_aml.py
+++ b/diabetes_regression/training/train_aml.py
@@ -32,6 +32,7 @@ import json
 from train import split_data, train_model, get_model_metrics
 
 from util.logger import setup
+from util.metric_logger import MetricLogger
 import logging
 
 def register_dataset(
@@ -124,10 +125,12 @@ def main():
 
     # Log the training parameters
     logging.info(f"Parameters: ", extra={'custom_dimensions': train_args})
+    custom_dimension = {}
     for (k, v) in train_args.items():
         run.log(k, v)
         run.parent.log(k, v)
         logging.info(f"{k}: {v}")
+        custom_dimension[f'Parameter: {k}'] = v
 
     # Get the dataset
     if (dataset_name):
@@ -160,6 +163,10 @@ def main():
         run.log(k, v)
         run.parent.log(k, v)
         logging.info(f"{k}: {v}")
+        # Log this metric to the `customMetric` table of App insights
+        metric_logger = MetricLogger("Model metric: " + k)
+        metric_logger.set_customdimension(custom_dimension)
+        metric_logger.set_metric_value(float(v))
 
     # Pass model file to next step
     os.makedirs(step_output_path, exist_ok=True)

--- a/diabetes_regression/util/metric_logger.py
+++ b/diabetes_regression/util/metric_logger.py
@@ -1,0 +1,42 @@
+from opencensus.ext.azure import metrics_exporter
+from opencensus.stats import aggregation as aggregation_module
+from opencensus.stats import measure as measure_module
+from opencensus.stats import stats as stats_module
+from opencensus.stats import view as view_module
+from opencensus.tags import tag_map as tag_map_module
+import os
+
+class MetricLogger:
+    def __init__(self, metric_name:str, custom_dimension_keys:list=[]):
+        self.custom_dimension_keys = custom_dimension_keys
+        stats = stats_module.stats
+        view_manager = stats.view_manager
+        stats_recorder = stats.stats_recorder
+        self.metric_measure_module = measure_module.MeasureFloat("Metric", "", "")
+
+        request_view = view_module.View(metric_name, "",
+                                        self.custom_dimension_keys,
+                                        self.metric_measure_module,
+                                        aggregation_module.LastValueAggregation())
+
+        exporter = metrics_exporter.new_metrics_exporter(connection_string=f'InstrumentationKey={os.environ.get("APPINSIGHTS_INSTRUMENTATION_KEY")}')
+        
+        view_manager.register_exporter(exporter)
+
+        view_manager.register_view(request_view)
+        self.mmap = stats_recorder.new_measurement_map()
+        self.tmap = tag_map_module.TagMap()
+
+    def insert_customdimension(self, key: str, value: str):
+        if key not in self.custom_dimension_keys:
+            self.custom_dimension_keys.append(key)
+        
+        self.tmap.insert(key, value)
+    
+    def set_customdimension(self, custom_dimension: dict):
+        for key, value in custom_dimension.items():
+            self.insert_customdimension(key, str(value))
+
+    def set_metric_value(self, value:float):
+        self.mmap.measure_float_put(self.metric_measure_module, value)
+        self.mmap.record(self.tmap)


### PR DESCRIPTION
## Description 
This PR implemented the logging of a metric data into `customMetric` table. 

Please note of the following:
1. Class is created to facilitate the logging, see metric_logging.py
1. `customDimensions` is also implemented in this PR just to showcase how to include `customDimension`

To run this PR:
1. `python -m ml_service.pipelines.diabetes_regression_build_train_pipeline`

### This is the log in the `customMetric` table
![image](https://user-images.githubusercontent.com/308396/94878962-73881800-0491-11eb-9761-601305c8716b.png)

