### PR TITLE
UC-141: Clean CD Jenkins pipelines to move to public repo

### DIFF
--- a/.pipelines/build-model-container-image.Jenkinsfile
+++ b/.pipelines/build-model-container-image.Jenkinsfile
@@ -62,16 +62,15 @@ pipeline {
 
                 sh '''#!/bin/bash -ex
                     az acr login --name $ML_CONTAINER_REGISTRY
-                    docker build -t $NEXUS_DOCKER_REPO_HTTP_URL/$IMAGE_NAME:$BUILD_ID ./diabetes_regression/scoring/$ML_IMAGE_FOLDER/ 
+                    docker build -t $NEXUS_DOCKER_REPO_BASE_URL/$IMAGE_NAME:$BUILD_ID ./diabetes_regression/scoring/$ML_IMAGE_FOLDER/ 
                 '''
 
                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "${NEXUS_DOCKER_CREDENTIALS_NAME}",
                     usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
                         
                     sh '''#!/bin/bash -ex
-                        docker login -u $USERNAME --password $PASSWORD http://$NEXUS_DOCKER_REPO_HTTP_URL
-                        docker push $NEXUS_DOCKER_REPO_HTTP_URL/$IMAGE_NAME:$BUILD_ID
-                        
+                        docker login -u $USERNAME --password $PASSWORD https://$NEXUS_DOCKER_REPO_BASE_URL
+                        docker push $NEXUS_DOCKER_REPO_BASE_URL/$IMAGE_NAME:$BUILD_ID
                     '''
                 }
             }

--- a/.pipelines/build-model-container-image.Jenkinsfile
+++ b/.pipelines/build-model-container-image.Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                         az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID
                         az account set -s $AZURE_SUBSCRIPTION_ID
                         export SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID
-                        source /home/azureuser/anaconda3/bin/activate $DEFAULT_CONDA_ENV_NAME
+                        conda activate $DEFAULT_CONDA_ENV_NAME
                         python3 -m ml_service.util.create_scoring_image
                     '''
                 }

--- a/.pipelines/build-model-container-image.Jenkinsfile
+++ b/.pipelines/build-model-container-image.Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                         az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID
                         az account set -s $AZURE_SUBSCRIPTION_ID
                         export SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID
-                        conda activate $DEFAULT_CONDA_ENV_NAME
+                        source $CONDA_PATH/activate $DEFAULT_CONDA_ENV_NAME
                         python3 -m ml_service.util.create_scoring_image
                     '''
                 }

--- a/.pipelines/build-model-container-image.Jenkinsfile
+++ b/.pipelines/build-model-container-image.Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
         RESOURCE_GROUP          = "${RESOURCE_GROUP}"
         WORKSPACE_NAME          = "${WORKSPACE_NAME}"
         ML_CONTAINER_REGISTRY   = "${ML_CONTAINER_REGISTRY}"
+        DEFAULT_CONDA_ENV_NAME  = 'mlopspython_ci_env'
     }
     stages {
         stage('initialize') {
@@ -42,7 +43,7 @@ pipeline {
                 checkout scm
 
                 sh '''
-                    conda env create --file ./diabetes_regression/ci_dependencies.yml --force 
+                    conda env create --name $DEFAULT_CONDA_ENV_NAME --file ./diabetes_regression/ci_dependencies.yml --force 
                 '''
                 
                 withCredentials([azureServicePrincipal("${AZURE_SP}")]) {
@@ -50,7 +51,7 @@ pipeline {
                         az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID
                         az account set -s $AZURE_SUBSCRIPTION_ID
                         export SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID
-                        source /home/azureuser/anaconda3/bin/activate mlopspython_ci
+                        source /home/azureuser/anaconda3/bin/activate $DEFAULT_CONDA_ENV_NAME
                         python3 -m ml_service.util.create_scoring_image
                     '''
                 }

--- a/.pipelines/build-model-container-image.Jenkinsfile
+++ b/.pipelines/build-model-container-image.Jenkinsfile
@@ -62,15 +62,16 @@ pipeline {
 
                 sh '''#!/bin/bash -ex
                     az acr login --name $ML_CONTAINER_REGISTRY
-                    docker build -t $NEXUS_DOCKER_REGISTRY_URL/$IMAGE_NAME:$BUILD_ID ./diabetes_regression/scoring/$ML_IMAGE_FOLDER/ 
+                    docker build -t $NEXUS_DOCKER_REPO_HTTP_URL/$IMAGE_NAME:$BUILD_ID ./diabetes_regression/scoring/$ML_IMAGE_FOLDER/ 
                 '''
 
                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "${NEXUS_DOCKER_CREDENTIALS_NAME}",
                     usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
                         
                     sh '''#!/bin/bash -ex
-                        docker login -u $USERNAME --password $PASSWORD https://$NEXUS_DOCKER_REGISTRY_URL
-                        docker push $NEXUS_DOCKER_REGISTRY_URL/$IMAGE_NAME:$BUILD_ID
+                        docker login -u $USERNAME --password $PASSWORD http://$NEXUS_DOCKER_REPO_HTTP_URL
+                        docker push $NEXUS_DOCKER_REPO_HTTP_URL/$IMAGE_NAME:$BUILD_ID
+                        
                     '''
                 }
             }

--- a/.pipelines/deploy-model-to-appservice.Jenkinsfile
+++ b/.pipelines/deploy-model-to-appservice.Jenkinsfile
@@ -2,7 +2,6 @@ pipeline {
     agent { label 'master' }
     environment {
         ML_IMAGE_FOLDER = 'imagefiles'
-        IMAGE_NAME      = 'mlmodelimage'
         MODEL_NAME      = "${MODEL_NAME}"
         SCORE_SCRIPT    = 'scoring/score.py'
         RESOURCE_GROUP  = "${RESOURCE_GROUP}"

--- a/ml_service/util/scoring/requirements.txt
+++ b/ml_service/util/scoring/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.18.*
 joblib==0.16.0
-azureml-sdk==1.14.*
-azureml-defaults==1.14.*
+azureml-sdk
+azureml-defaults
 inference-schema[numpy-support]
 sklearn


### PR DESCRIPTION
- Remove unused parameters.
- Use https URL (base) of Nexus docker registry to push to docker repository
- Use parameters if the environment variables need to change.
- Remove the dependency on conda environment name in YML file

2 Jenkins pipelines:
- http://merlion-jenkins-vm.eastasia.cloudapp.azure.com:8080/job/build-mlmodel-container-image-to-Nexus/
- http://merlion-jenkins-vm.eastasia.cloudapp.azure.com:8080/job/merlion-deploy-mlmodel-2-appservice/