### PR TITLE
UC-139: BugFix: Include observability related python libraries to the docker image 

### DIFF
--- a/jenkins-pipelines/.properties
+++ b/jenkins-pipelines/.properties
@@ -39,7 +39,7 @@ IMAGE_NAME="diabetestrained"
 #  ALLOW_RUN_CANCEL=true
 
 # Flag to allow rebuilding the AML Environment after it was built for the first time. This enables dependency updates from conda_dependencies.yaml.
-AML_REBUILD_ENVIRONMENT=false
+AML_REBUILD_ENVIRONMENT=true
 
 # Variables below are used for controlling various aspects of batch scoring
 USE_GPU_FOR_SCORING=False

--- a/jenkins-pipelines/.properties
+++ b/jenkins-pipelines/.properties
@@ -15,7 +15,7 @@ DATASET_NAME=diabetes_ds
 # Uncomment DATASTORE_NAME if you have configured non default datastore to point to your data
 # DATASTORE_NAME=datablobstore
 DATASET_VERSION=latest
-TRAINING_PIPELINE_NAME=diabetes-Training-Pipeline
+TRAINING_PIPELINE_NAME=diabetes-training-pipeline
 MODEL_NAME=diabetes_regression_model.pkl
 
 # AML Compute Cluster Config

--- a/jenkins-pipelines/.properties
+++ b/jenkins-pipelines/.properties
@@ -15,7 +15,7 @@ DATASET_NAME=diabetes_ds
 # Uncomment DATASTORE_NAME if you have configured non default datastore to point to your data
 # DATASTORE_NAME=datablobstore
 DATASET_VERSION=latest
-TRAINING_PIPELINE_NAME=diabetes-training-pipeline
+TRAINING_PIPELINE_NAME=diabetes-Training-Pipeline
 MODEL_NAME=diabetes_regression_model.pkl
 
 # AML Compute Cluster Config

--- a/jenkins-pipelines/diabetes_regression_ci-Jenkinsfile
+++ b/jenkins-pipelines/diabetes_regression_ci-Jenkinsfile
@@ -8,7 +8,8 @@ pipeline {
     agent {
         docker {
             //Azure CLI commands require root privileges
-            image 'mcr.microsoft.com/mlops/python:latest'
+            //Pull down the docker image from Nexus Private Registry and use that image as an agent
+            image '52.175.54.34:8123/mlopspython:latest'
             label 'master'
             args "--user root --privileged"
         }
@@ -18,6 +19,7 @@ pipeline {
         string(name: 'SUBSCRIPTION_ID', defaultValue: '371e8e7f-bce0-4db0-9df5-d88805b41101', description: 'Azure Subscription ID')
         string(name: 'RESOURCE_GROUP', defaultValue: 'swsundar-upskill', description: 'Azure Resource Group Name')
         string(name: 'SERVICE_PRINCIPAL_NAME', defaultValue: 'swsundar-azure-spn', description: 'Azure Service Principal Name')
+        string(name: 'APPINSIGHTS_INSTRUMENTATION_KEY', description: 'Application Insights Instrumentation Key for publishing logs to Azure')
     }
     environment {
         //Pass the Jenkins' Build ID as an environment variable for tracking

--- a/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
+++ b/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
@@ -14,7 +14,7 @@ import logging
 
 def main():
     e = Env()
-    setup_logging(log_to_local_only=True)
+    setup_logging(log_to_local_only=False)
 
     # Get Azure machine learning workspace
     aml_workspace = Workspace.get(

--- a/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
+++ b/ml_service/pipelines/diabetes_regression_build_train_pipeline.py
@@ -14,7 +14,7 @@ import logging
 
 def main():
     e = Env()
-    setup_logging(False)
+    setup_logging(log_to_local_only=True)
 
     # Get Azure machine learning workspace
     aml_workspace = Workspace.get(
@@ -105,7 +105,7 @@ def main():
     pipeline_data = PipelineData(
         "pipeline_data", datastore=aml_workspace.get_default_datastore()
     )
-    
+
     train_step = PythonScriptStep(
         name="Train Model",
         script_name=e.train_script_path,

--- a/ml_service/util/logger.py
+++ b/ml_service/util/logger.py
@@ -17,12 +17,12 @@ def setup_logging(log_to_local_only: bool = False, env: Env = None):
     """
     if env is None:
         env = Env()
-    
+
     logging.config.dictConfig(logging_config)
     logger = getLogger()
 
     if not log_to_local_only:
-    # Assumes the environment variable APPLICATIONINSIGHTS_CONNECTION_STRING is already set
+    # Assumes the environment variable APPINSIGHTS_INSTRUMENTATION_KEY is already set
         azure_log_handler = AzureLogHandler(
             instrumentation_key=env.appinsights_instrumentation_key,
             storage_path='logs'


### PR DESCRIPTION
#### Description:

- BugFix: Build a docker image including the observability related libraries: opencensus
- Publish the docker image to Nexus private registry and use the published image in the CI Jenkins pipeline as a docker agent
- Enable the Azure ML Environment Rebuild flag to true to take new libraries into effect

#### Test:
Here's a sample pipeline run with the AppInsights key and logs getting published to Azure AppInsights: 

http://swsundar-jenkins-financeforecasting.eastasia.cloudapp.azure.com:8080/job/demo-aml-build-pipeline/21/console

